### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -1,4 +1,6 @@
 name: Fly Deploy
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/spwg/personal-website/security/code-scanning/1](https://github.com/spwg/personal-website/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not appear to require `write` permissions, we will set the permissions to `contents: read` at the workflow level. This ensures that the `GITHUB_TOKEN` has the least privilege necessary, adhering to security best practices.

The changes will be made to the `.github/workflows/fly.yml` file:
1. Add a `permissions` block at the root level of the workflow, specifying `contents: read`.

No additional methods, imports, or definitions are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
