### PR TITLE
add ASE 2026 FlowAgent paper to publications

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -79,7 +79,8 @@ li {
   line-height: 1.5;
 }
 
-li a:first-child {
+li a:first-child,
+li .title {
   font-weight: 500;
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -23,6 +23,7 @@
     <section>
       <h2>Publications</h2>
       <ul>
+        <li><span class="title">Catching Developers In The Flow: Low-Latency Agentic Program Repair At Google Scale</span> — ASE 2026</li>
         <li><a href="https://arxiv.org/abs/2604.12108">LLM-Based Automated Diagnosis of Integration Test Failures at Google</a> — ICSE 2026</li>
       </ul>
     </section>


### PR DESCRIPTION
Adds "Catching Developers In The Flow: Low-Latency Agentic Program
Repair At Google Scale" (ASE 2026). No link yet since the paper isn't
on arXiv and the DOI isn't assigned, so the title renders as plain
text styled to match linked publication titles.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T9GsfRp8GTNwRee2mmzJkJ